### PR TITLE
Add line_items to subscription order map stream.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-woo"
-version = "0.0.2"
+version = "0.1.0"
 description = "`tap-woo` is a Singer tap for woo, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Peter Butler <peterbutler@automattic.com>"]

--- a/tap_woo/streams.py
+++ b/tap_woo/streams.py
@@ -388,8 +388,9 @@ class SubscriptionOrdersStream(wooStream):
     schema = th.PropertiesList(
         th.Property(
             "subscription_id", th.IntegerType
-        ),  # This seems to come from the parent stream, although I dont understand how
+        ),
         th.Property("order_id", th.IntegerType),
+        LINE_ITEMS_FIELD_SCHEMA,
     ).to_dict()
 
     def post_process(self, row: dict, context: dict | None = None) -> dict | None:


### PR DESCRIPTION
Initially, I thought just mapping order and subscription was enough - but before using this in a production pipeline, I wanted to be sure this wouldnt cause issues.   The initial assumption was that all line items in an order would be associated with at most a single subscription.  This doesnt seem to be true, however:

The [Woo Subscriptions docs confirm](https://woo.com/document/subscriptions/develop/multiple-subscriptions/#section-3)  indicate that line items _are_ grouped into subscriptions, but they are grouped based on renew interval - not just on order.  In practice, this means a subscription may have line items on a single order pointing to multiple subscriptions - which means we have to include line item data in the tap to be able to map line items to subscriptions accurately over time.