### PR TITLE
Fix line item image id type error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-woo"
-version = "0.1.0"
+version = "0.1.1"
 description = "`tap-woo` is a Singer tap for woo, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Peter Butler <peterbutler@automattic.com>"]

--- a/tap_woo/helpers/common_fields.py
+++ b/tap_woo/helpers/common_fields.py
@@ -138,7 +138,7 @@ LINE_ITEMS_FIELD_SCHEMA = th.Property(
             th.Property(
                 "image",
                 th.ObjectType(
-                    th.Property("id", th.StringType), th.Property("src", th.StringType)
+                    th.Property("id", th.IntegerType), th.Property("src", th.StringType)
                 ),
             ),
             th.Property("parent_name", th.StringType),


### PR DESCRIPTION
line item image id is set to be a string, but is, in fact, an integer.  This breaks the ingestion whenever there is a line item image, I beleive.

I did a quick scan through other "id"s, they're all already set to be integers.