### PR TITLE
Fix: Removing image property from line items

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-woo"
-version = "0.1.1"
+version = "0.1.2"
 description = "`tap-woo` is a Singer tap for woo, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Peter Butler <peterbutler@automattic.com>"]

--- a/tap_woo/helpers/common_fields.py
+++ b/tap_woo/helpers/common_fields.py
@@ -135,12 +135,6 @@ LINE_ITEMS_FIELD_SCHEMA = th.Property(
             METADATA_FIELD_SCHEMA,
             th.Property("sku", th.BooleanType),
             th.Property("price", th.NumberType),
-            th.Property(
-                "image",
-                th.ObjectType(
-                    th.Property("id", th.CustomType({"type": ["string", "number"]})), th.Property("src", th.StringType)
-                ),
-            ),
             th.Property("parent_name", th.StringType),
         )
     ),

--- a/tap_woo/helpers/common_fields.py
+++ b/tap_woo/helpers/common_fields.py
@@ -138,7 +138,7 @@ LINE_ITEMS_FIELD_SCHEMA = th.Property(
             th.Property(
                 "image",
                 th.ObjectType(
-                    th.Property("id", th.IntegerType), th.Property("src", th.StringType)
+                    th.Property("id", th.CustomType({"type": ["string", "number"]})), th.Property("src", th.StringType)
                 ),
             ),
             th.Property("parent_name", th.StringType),


### PR DESCRIPTION
Removed the image property from line items as it is not included in the documentation and this object's data types are not reliable.