### PR TITLE
Fix: Subscription schema > removed_line_items

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-woo"
-version = "0.1.2"
+version = "0.1.3"
 description = "`tap-woo` is a Singer tap for woo, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Peter Butler <peterbutler@automattic.com>"]

--- a/tap_woo/streams.py
+++ b/tap_woo/streams.py
@@ -348,7 +348,7 @@ class SubscriptionsStream(wooStream):
         th.Property("end_date_gmt", th.DateTimeType),
         th.Property("resubscribed_from", th.StringType),
         th.Property("resubscribed_subscription", th.StringType),
-        th.Property("removed_line_items", th.ArrayType(th.IntegerType)),
+        th.Property("removed_line_items", th.ArrayType(th.ObjectType(LINE_ITEMS_FIELD_SCHEMA))),
         th.Property("payment_url", th.StringType),
         th.Property("is_editable", th.BooleanType),
         th.Property("needs_payment", th.BooleanType),


### PR DESCRIPTION
The `removed_line_items` in Subscription schema is not an integer according to the [docs](https://woocommerce.github.io/subscriptions-rest-api-docs/#subscription-line-item-properties), but it's a line item property.

Tested locally.