### PR TITLE
Mark fields required where the warehouse schema declares them NOT NULL

### DIFF
--- a/tap_woo/streams.py
+++ b/tap_woo/streams.py
@@ -42,10 +42,10 @@ class OrdersStream(wooStream):
         th.Property("status", th.StringType),
         th.Property("currency", th.StringType),
         th.Property("currency_symbol", th.StringType),
-        th.Property("date_created", th.DateTimeType),
-        th.Property("date_created_gmt", th.DateTimeType),
-        th.Property("date_modified", th.DateTimeType),
-        th.Property("date_modified_gmt", th.DateTimeType),
+        th.Property("date_created", th.DateTimeType, required=True),
+        th.Property("date_created_gmt", th.DateTimeType, required=True),
+        th.Property("date_modified", th.DateTimeType, required=True),
+        th.Property("date_modified_gmt", th.DateTimeType, required=True),
         th.Property("discount_total", th.StringType),
         th.Property("discount_tax", th.StringType),
         th.Property("shipping_total", th.StringType),
@@ -117,7 +117,7 @@ class RefundsStream(wooStream):
     state_partitioning_keys: list[str] = []
 
     schema = th.PropertiesList(
-        th.Property("id", th.IntegerType),
+        th.Property("id", th.IntegerType, required=True),
         th.Property("original_order_id", th.IntegerType),
         th.Property("date_created", th.DateTimeType),
         th.Property("date_created_gmt", th.DateTimeType),
@@ -149,7 +149,7 @@ class ProductsStream(wooStream):
     is_sorted = False
 
     schema = th.PropertiesList(
-        th.Property("id", th.IntegerType),
+        th.Property("id", th.IntegerType, required=True),
         th.Property("name", th.StringType),
         th.Property("slug", th.StringType),
         th.Property("permalink", th.StringType),
@@ -348,16 +348,16 @@ class SubscriptionsStream(wooStream):
     is_sorted = False
 
     schema = th.PropertiesList(
-        th.Property("id", th.IntegerType),
+        th.Property("id", th.IntegerType, required=True),
         th.Property("parent_id", th.IntegerType),
-        th.Property("status", th.StringType),
+        th.Property("status", th.StringType, required=True),
         th.Property("currency", th.StringType),
         th.Property("version", th.StringType),
         th.Property("prices_include_tax", th.BooleanType),
-        th.Property("date_created", th.DateTimeType),
-        th.Property("date_modified", th.DateTimeType),
-        th.Property("date_created_gmt", th.DateTimeType),
-        th.Property("date_modified_gmt", th.DateTimeType),
+        th.Property("date_created", th.DateTimeType, required=True),
+        th.Property("date_modified", th.DateTimeType, required=True),
+        th.Property("date_created_gmt", th.DateTimeType, required=True),
+        th.Property("date_modified_gmt", th.DateTimeType, required=True),
         th.Property("discount_total", th.StringType),
         th.Property("discount_tax", th.StringType),
         th.Property("shipping_total", th.StringType),
@@ -365,7 +365,7 @@ class SubscriptionsStream(wooStream):
         th.Property("cart_tax", th.StringType),
         th.Property("total", th.StringType),
         th.Property("total_tax", th.StringType),
-        th.Property("customer_id", th.IntegerType),
+        th.Property("customer_id", th.IntegerType, required=True),
         th.Property("order_key", th.StringType),
         BILLING_FIELD_SCHEMA,
         SHIPPING_FIELD_SCHEMA,
@@ -373,7 +373,7 @@ class SubscriptionsStream(wooStream):
         th.Property("payment_method_title", th.StringType),
         th.Property("customer_ip_address", th.StringType),
         th.Property("customer_user_agent", th.StringType),
-        th.Property("created_via", th.StringType),
+        th.Property("created_via", th.StringType, required=True),
         th.Property("customer_note", th.StringType),
         th.Property("date_completed", th.DateTimeType),
         th.Property("date_paid", th.DateTimeType),
@@ -396,9 +396,9 @@ class SubscriptionsStream(wooStream):
         ),
         th.Property("date_completed_gmt", th.DateTimeType),
         th.Property("date_paid_gmt", th.DateTimeType),
-        th.Property("billing_period", th.StringType),
-        th.Property("billing_interval", th.StringType),
-        th.Property("start_date_gmt", th.DateTimeType),
+        th.Property("billing_period", th.StringType, required=True),
+        th.Property("billing_interval", th.StringType, required=True),
+        th.Property("start_date_gmt", th.DateTimeType, required=True),
         th.Property("trial_end_date_gmt", th.DateTimeType),
         th.Property("next_payment_date_gmt", th.DateTimeType),
         th.Property("last_payment_date_gmt", th.DateTimeType),
@@ -445,9 +445,8 @@ class SubscriptionOrdersStream(wooStream):
 
     schema = th.PropertiesList(
         th.Property(
-            "subscription_id", th.IntegerType
-        ),
-        th.Property("order_id", th.IntegerType),
+            "subscription_id", th.IntegerType, required=True),
+        th.Property("order_id", th.IntegerType, required=True),
         LINE_ITEMS_FIELD_SCHEMA,
     ).to_dict()
 


### PR DESCRIPTION
## What

Adds `required=True` to 19 properties across five streams, so the emitted JSON Schema matches what the consuming warehouse (Wyeast / nosara AVDL) declares for the corresponding tables.

| stream | fields marked required |
|---|---|
| `orders` | `date_created`, `date_created_gmt`, `date_modified`, `date_modified_gmt` |
| `products` | `id` |
| `refunds` | `id` |
| `subscription_orders` | `subscription_id`, `order_id` |
| `subscriptions` | `id`, `status`, `date_created`, `date_modified`, `date_created_gmt`, `date_modified_gmt`, `customer_id`, `created_via`, `billing_period`, `billing_interval`, `start_date_gmt` |

## Why

The nosara AVDL declares these columns NOT NULL on `billing_sources.sensei_iceberg_*`, but every property here was emitted as optional, so `target-iceberg` created nullable Iceberg columns. When those tables were promoted to enforced NOT NULL metadata, the loader aborted every run with a schema mismatch — the daily `senseilms_woostore_meltano_elt` task failed repeatedly with:

```
❌ │ 10: date_created: required     │ 10: date_created: optional
❌ │ 11: date_created_gmt: required │ 11: date_created_gmt: optional
❌ │ 12: date_modified: required    │ 12: date_modified: optional
```

(left: the table; right: this tap's schema). The warehouse-side promotion has been rolled back for now, so the ELT is healthy; this change is what allows it to be re-applied.

## Safety

`required=True` has two effects on the emitted schema — the field joins the `required` list, and its type union drops `"null"`. That means a genuinely-absent value would now fail the load rather than landing as NULL, so the fields were chosen conservatively:

- only fields the warehouse already declares NOT NULL, and
- all of them verified fully populated in production: a NULL scan across the existing warehouse data for these tables found **zero** nulls in any of these columns.

Fields where the API legitimately omits values were deliberately left optional.

## Verification

Schemas were rendered from the modified streams and inspected directly:

```
orders: 4 required -> {'date_created': ['string'], ...}
products: 1 required -> {'id': ['integer']}
refunds: 1 required -> {'id': ['integer']}
subscription_orders: 2 required -> {'subscription_id': ['integer'], 'order_id': ['integer']}
subscriptions: 11 required -> {'id': ['integer'], 'status': ['string'], ...}
```

Each required field's type no longer includes `"null"`, which is what `target-iceberg` needs to create a required column. The repo's own test suite (`tests/test_core.py`) runs the SDK's standard tap tests against a live store and needs real credentials, so it was not run here.

## Follow-up (not in this PR)

- `sensei_iceberg_orders.synced_ms` is also declared NOT NULL in the AVDL, but that column is added by `target-iceberg`, not by this tap — it needs handling on the loader side (or relaxing in the AVDL).
- After this is released, the pinned version in nosara (`resources/tap-woo.yml`, currently `v0.1.7`) needs bumping before the warehouse columns can be re-promoted.
- The same required-vs-optional conflict affects `appstore_input.appstore_*_raw_*` via `tap-appstore`; the same treatment would apply there.